### PR TITLE
fix(encoding): switch to utf-8 encoding by default

### DIFF
--- a/src/Deserializer.ts
+++ b/src/Deserializer.ts
@@ -27,7 +27,7 @@ export class Deserializer {
 
   static isInteger = /^-?\d+$/;
 
-  constructor(encoding: Encoding = "utf8") {
+  constructor(encoding: Encoding = "utf-8") {
     this._encoding = encoding;
     this._parser = sax.createStream();
     this._parser.on("opentag", this._onOpentag);

--- a/src/XmlRpcClient.test.ts
+++ b/src/XmlRpcClient.test.ts
@@ -62,7 +62,7 @@ describe("XmlRpcClient", () => {
       });
   });
 
-  it("Can call a method with UTF8 encoding", (done) => {
+  it("Can call a method with UTF-8 encoding", (done) => {
     const server = http
       .createServer((_, res) => {
         res.writeHead(200, { "Content-Type": "text/xml" });
@@ -90,7 +90,7 @@ describe("XmlRpcClient", () => {
     let requestBody = "";
     const server = http
       .createServer((req, res) => {
-        req.setEncoding("utf8");
+        req.setEncoding("utf-8");
         req.on("data", (chunk: string) => {
           requestBody += chunk;
         });

--- a/src/XmlRpcTypes.ts
+++ b/src/XmlRpcTypes.ts
@@ -14,7 +14,6 @@ export type XmlRpcStruct = { [key: string]: XmlRpcValue };
 
 export type Encoding =
   | "ascii"
-  | "utf8"
   | "utf-8"
   | "utf16le"
   | "ucs2"


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
this change changes the default encoding to `utf-8` and removes the `utf8` encoding.

**Description**
<!-- describe what has changed, and motivation behind those changes -->
rather than using utf8 (without the dash). This is to make it conform to
tools expecting this format on the other side.


Fixes foxglove/studio#2072

<!-- link relevant GitHub issues -->
