### PR TITLE
Remove writeHead() in favor of sending full response via .end() to disable Transfer-Encoding: chunked

### DIFF
--- a/src/nodejs/HttpServerNodejs.ts
+++ b/src/nodejs/HttpServerNodejs.ts
@@ -22,7 +22,11 @@ export class HttpServerNodejs implements HttpServer {
           .then((out) => {
             // Write the HTTP response
             res.shouldKeepAlive = out.shouldKeepAlive ?? res.shouldKeepAlive;
-            res.writeHead(out.statusCode, out.statusMessage, out.headers);
+            res.statusCode = out.statusCode;
+            res.statusMessage = out.statusMessage ?? "";
+            for (const [key, value] of Object.entries(out.headers ?? {})) {
+              res.setHeader(key, value);
+            }
             res.end(out.body);
           })
           .catch((err) => {


### PR DESCRIPTION
**Public-Facing Changes**

* `Transfer-Encoding: chunked` is no longer used for XML-RPC server responses

