### PR TITLE
Don't return errors with Transfer-Encoding: chunked

### DIFF
--- a/examples/server.ts
+++ b/examples/server.ts
@@ -13,7 +13,11 @@ async function main() {
     return [res];
   });
   await xmlrpc.listen(8000);
-  console.info(`Listening on ${xmlrpc.server.url() ?? "http://localhost:8000"}`);
+  const url = xmlrpc.server.url() ?? "http://localhost:8000";
+  console.info(`Listening on ${url}`);
+  console.log(
+    `Try running: curl --data "<methodCall><methodName>sum</methodName><params><param><value><int>3</int></value></param><param><value><int>4</int></value></param></params></methodCall>" ${url}`,
+  );
 }
 
 void main();

--- a/src/nodejs/HttpServerNodejs.ts
+++ b/src/nodejs/HttpServerNodejs.ts
@@ -29,10 +29,14 @@ export class HttpServerNodejs implements HttpServer {
             }
             res.end(out.body);
           })
-          .catch((err) => {
+          .catch((maybeErr: unknown) => {
+            const err = maybeErr as Error;
+            const errStr = err.message;
             // Write an HTTP error response
-            res.writeHead(500, "Internal Server Error", { "Content-Type": "text/plain" });
-            res.end(String(err));
+            res.shouldKeepAlive = false;
+            res.statusCode = 500;
+            res.statusMessage = errStr;
+            res.end();
           });
       });
     });


### PR DESCRIPTION
**Public-Facing Changes**

* Error responses will no longer use `Transfer-Encoding: chunked`

**Description**

An example curl command is printed when starting the example server to verify behavior
