### PR TITLE
Allow NaN and infinity values in client and server

### DIFF
--- a/src/Deserializer.ts
+++ b/src/Deserializer.ts
@@ -221,7 +221,19 @@ export class Deserializer {
   private _endDouble = (data: string): void => {
     const value = parseFloat(data);
     if (isNaN(value)) {
-      throw new Error("Expected a double but got '" + data + "'");
+      const lower = data.toLowerCase();
+      if (lower === "nan") {
+        this._push(NaN);
+        this._value = false;
+      } else if (lower === "-inf" || lower === "-infinity") {
+        this._push(-Infinity);
+        this._value = false;
+      } else if (lower === "inf" || lower === "infinity") {
+        this._push(Infinity);
+        this._value = false;
+      } else {
+        throw new Error("Expected a double but got '" + data + "'");
+      }
     } else {
       this._push(value);
       this._value = false;

--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -176,6 +176,12 @@ function appendString(value: string, xml: XMLBuilder) {
 function appendNumber(value: number, xml: XMLBuilder) {
   if (value % 1 === 0) {
     xml.ele("int").txt(String(value));
+  } else if (value === Infinity) {
+    xml.ele("double").txt("inf");
+  } else if (value === -Infinity) {
+    xml.ele("double").txt("-inf");
+  } else if (isNaN(value)) {
+    xml.ele("double").txt("nan");
   } else {
     xml.ele("double").txt(String(value));
   }


### PR DESCRIPTION
**Public-Facing Changes**

- NaN and Infinity values are properly serialized and parsed by client and server

**Description**

Although disallowed by the XMLRPC spec (see https://issues.apache.org/jira/browse/XMLRPC-146), nan/inf values are sometimes sent by non-compliant clients or servers such as ROS1 parameter handling in the `roscore` service. This extends XmlRpcClient to parse double values that look like NaN or infinity instead of crashing. This library was already serializing NaN/Infinity values to strings (making it one of those non-compliant codebases), but disabling this behavior would be a major breaking change so instead I've opted to normalize the string formatting to "nan", "-inf", and "inf". A future PR could add a toggle to disable serializing these values and throw an exception instead.
