### PR TITLE
Serialize empty strings as <string></string> instead of <string/>

### DIFF
--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -164,9 +164,7 @@ function appendBoolean(value: boolean, xml: XMLBuilder) {
 }
 
 function appendString(value: string, xml: XMLBuilder) {
-  if (value.length === 0) {
-    xml.ele("string");
-  } else if (!illegalChars.test(value)) {
+  if (!illegalChars.test(value)) {
     xml.ele("string").dat(value);
   } else {
     xml.ele("string").txt(value);

--- a/src/XmlRpcServer.test.ts
+++ b/src/XmlRpcServer.test.ts
@@ -66,7 +66,7 @@ describe("XmlRpcServer", () => {
       handledMethod = true;
       expect(methodName).toEqual("testMethod");
       expect(args).toEqual([42, -Infinity, NaN]);
-      return await Promise.resolve([1, "test", undefined]);
+      return await Promise.resolve([1, "test", "", undefined]);
     });
     server.listen().then(() => {
       const port = parseInt(new URL(server.server.url() as string).port);
@@ -99,7 +99,7 @@ describe("XmlRpcServer", () => {
         res.on("data", (chunk: string) => (resData += chunk));
         res.on("end", () => {
           expect(resData).toEqual(
-            '<?xml version="1.0"?><methodResponse><params><param><value><array><data><value><int>1</int></value><value><string>test</string></value><value/></data></array></value></param></params></methodResponse>',
+            '<?xml version="1.0"?><methodResponse><params><param><value><array><data><value><int>1</int></value><value><string>test</string></value><value><string></string></value><value/></data></array></value></param></params></methodResponse>',
           );
           server.close();
           done();


### PR DESCRIPTION
**Public-Facing Changes**

* Empty strings are serialized as `<string></string>` instead of `<string/>`

**Description**

This should improve compatibility with the ROS C++ XMLRPC client

<!-- describe what has changed, and motivation behind those changes -->


<!-- link relevant GitHub issues -->
