### PR TITLE
Add http request as the last param for a method call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
-      - run: yarn run lint:ci
       - run: yarn run test
       - run: yarn run build
 
@@ -32,6 +31,9 @@ jobs:
       - name: build examples
         run: yarn tsc -b
         working-directory: ./examples
+
+      # lint needs to run after examples yarn install since it also lints the examples
+      - run: yarn run lint:ci
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,13 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
-      - name: yarn install examples
-        run: yarn install --frozen-lockfile
-        working-directory: ./examples
       - run: yarn run build
       - run: yarn run lint:ci
       - run: yarn run test
+
+      - name: yarn install examples
+        run: yarn install --frozen-lockfile
+        working-directory: ./examples
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,17 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile
-      - run: yarn run build
       - run: yarn run lint:ci
       - run: yarn run test
+      - run: yarn run build
 
+      # install dependencies for examples (including reference back to main package)
       - name: yarn install examples
         run: yarn install --frozen-lockfile
+        working-directory: ./examples
+      # make sure the examples build
+      - name: build examples
+        run: yarn tsc -b
         working-directory: ./examples
 
       - name: Publish to NPM

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "server": "ts-node server.ts"
   },
   "dependencies": {
-    "@foxglove/xmlrpc": "latest"
+    "@foxglove/xmlrpc": "../"
   },
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -29,10 +29,8 @@
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-"@foxglove/xmlrpc@latest":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@foxglove/xmlrpc/-/xmlrpc-1.1.6.tgz#29e5cf8f38641b8629946381e3cfe22f9c1cab77"
-  integrity sha512-R6JMgJUtltvoyxdjk1zG9C3d092ABAcxRmwjUsdh/xNowNiB9sOKtzn4SctuBFEi+fME6x53SO/2U6hu5rZTPg==
+"@foxglove/xmlrpc@../":
+  version "1.2.1"
   dependencies:
     "@foxglove/just-fetch" "^1.2.4"
     byte-base64 "^1.1.0"

--- a/src/HttpTypes.ts
+++ b/src/HttpTypes.ts
@@ -2,6 +2,9 @@ export type HttpRequest = {
   body: string;
   method?: string;
   url?: string;
+  socket: {
+    localAddress?: string;
+  };
 };
 
 export type HttpResponse = {

--- a/src/HttpTypes.ts
+++ b/src/HttpTypes.ts
@@ -2,8 +2,11 @@ export type HttpRequest = {
   body: string;
   method?: string;
   url?: string;
-  socket: {
+  socket?: {
     localAddress?: string;
+    localPort?: number;
+    remoteAddress?: string;
+    remotePort?: number;
   };
 };
 

--- a/src/XmlRpcServer.ts
+++ b/src/XmlRpcServer.ts
@@ -75,7 +75,7 @@ export class XmlRpcServer {
         body = serializeMethodResponse(allResponses);
       }
     } else {
-      const res = await this._methodCallHandler(methodName, args);
+      const res = await this._methodCallHandler(methodName, args, req);
       body = res instanceof XmlRpcFault ? serializeFault(res) : serializeMethodResponse(res);
     }
 
@@ -90,6 +90,7 @@ export class XmlRpcServer {
   private _methodCallHandler = async (
     methodName: string,
     args: XmlRpcValue[],
+    req?: HttpRequest,
   ): Promise<XmlRpcValue | XmlRpcFault> => {
     const handler = this.xmlRpcHandlers.get(methodName);
     if (handler == undefined) {
@@ -97,7 +98,7 @@ export class XmlRpcServer {
     }
 
     try {
-      const res = await handler(methodName, args);
+      const res = await handler(methodName, args, req);
       return res;
     } catch (err) {
       return err instanceof XmlRpcFault

--- a/src/XmlRpcTypes.ts
+++ b/src/XmlRpcTypes.ts
@@ -1,3 +1,4 @@
+import { HttpRequest } from "./HttpTypes";
 import { XmlRpcFault } from "./XmlRpcFault";
 
 export type XmlRpcValue =
@@ -23,6 +24,10 @@ export type Encoding =
   | "binary"
   | "hex";
 
-export type XmlRpcMethodHandler = (methodName: string, args: XmlRpcValue[]) => Promise<XmlRpcValue>;
+export type XmlRpcMethodHandler = (
+  methodName: string,
+  args: XmlRpcValue[],
+  req?: HttpRequest,
+) => Promise<XmlRpcValue>;
 
 export type XmlRpcValueOrFault = XmlRpcValue | XmlRpcFault;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "references": [{ "path": "./examples" }],
   "include": ["./src/**/*.ts"],
   "compilerOptions": {
     "module": "commonjs",


### PR DESCRIPTION
In some rpc call handler implementations it is useful to have the original http request. One example would be to lookup the local address or remote address of the caller so use this information in the response.

This change adds the http request as an optional last argument to the rpc handler. The `HttpRequest` type is also updated with a `socket` field containing `localAddress`, `localPort`, `remoteAddress`, and `remotePort`. If the http server implementation is able to specify these fields it can do so.