### PR TITLE
Setup .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+*
+!/dist/**/*
+!/package.json
+!/README.md


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Exclude unneeded files from npm package dist.

Mainly `src` directory. It confused my IDE (PhpStorm), so I added debug to the wrong code without noticing the package had src folder also included, not just dist.

This also decreases `node_modules` on installations. ftw!